### PR TITLE
kitchen-opennebula: 0.1.1 release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.project

--- a/README.md
+++ b/README.md
@@ -109,6 +109,22 @@ To avoid test-kitchen's ssh tcp check in the create phase you can set `no_ssh_tc
 
 This variable configures a single sleep used when `no_ssh_tcp_check` is set to `true`. The default for `no_ssh_tcp_check` is 2 minutes.
 
+### <a name="no_passwordless_sudo_check"></a> no\_passwordless\_sudo\_check
+
+To avoid test-kitchen's passwordless sudo check in the create phase you can set `no_passwordless_sudo_check` to `true` and do single sleep instead. Sleep period is configured by `no_passwordless_sudo_sleep`. The default for `no_passwordless_sudo_check` is set to `false`.
+
+### <a name="no_passwordless_sudo_sleep"></a> no\_passwordless\_sudo\_sleep
+
+This variable configures a single sleep used when `no_passwordless_sudo_check` is set to `true`. The default for `no_passwordless_sudo_sleep` is 2 minutes.
+
+### <a name="passwordless_sudo_timeout"></a> passwordless\_sudo\_timeout
+
+This variable configures the max timeout will wait in the create phase for passwordless sudo to be setup. The variable is used when `no_passwordless_sudo_check` is set to `false`. The default for `passwordless_sudo_timeout` is 5 minutes.
+
+### <a name="passwordless_sudo_retry_interval"></a> passwordless\_sudo\_retry\_interval
+
+This variable configures retry interval in the create phase to periodically check that passwordless sudo is setup. It does this until max timeout (set by `passwordless_sudo_timeout`) is reached. The variable is used when `no_passwordless_sudo_check` is set to `false`. The default for `passwordless_sudo_retry_interval` is 10 seconds.
+
 ## <a name="development"></a> Development
 
 * Source hosted at [GitHub][repo]

--- a/README.md
+++ b/README.md
@@ -97,6 +97,18 @@ installed. There are several different behaviors available:
 
 The default value is unset, or `nil`.
 
+### <a name="wait_for"></a> wait_for
+
+This variable is used to override timeout for Fog's common `wait_for` method which states that it "takes a block and waits for either the block to return true for the object or for a timeout (defaults to 10 minutes)".
+
+### <a name="no_ssh_tcp_check"></a> no\_ssh\_tcp\_check
+
+To avoid test-kitchen's ssh tcp check in the create phase you can set `no_ssh_tcp_check` to `true` and do single sleep instead. Sleep period is configured by `no_ssh_tcp_check_sleep`. The default for `no_ssh_tcp_check` is set to `false`.
+
+### <a name="no_ssh_tcp_check_sleep"></a> no\_ssh\_tcp\_check\_sleep
+
+This variable configures a single sleep used when `no_ssh_tcp_check` is set to `true`. The default for `no_ssh_tcp_check` is 2 minutes.
+
 ## <a name="development"></a> Development
 
 * Source hosted at [GitHub][repo]

--- a/kitchen-opennebula.gemspec
+++ b/kitchen-opennebula.gemspec
@@ -18,8 +18,9 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'test-kitchen', '~> 1.2.0'
-  spec.add_dependency 'fog'
+  spec.add_dependency 'test-kitchen', '~> 1.2'
+  spec.add_dependency 'fog', '~> 1.26'
+  spec.add_dependency 'opennebula'
 
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake'

--- a/lib/kitchen/driver/opennebula.rb
+++ b/lib/kitchen/driver/opennebula.rb
@@ -85,11 +85,14 @@ module Kitchen
             :uid   => config[:template_uid]
           }
           newvm.flavor = conn.flavors.get_by_filter filter
+          if !newvm.flavor.nil? and newvm.flavor.length > 1
+            raise 'More than one template found.  Please restrict using template_uname'
+          end
+          newvm.flavor = newvm.flavor.first unless newvm.flavor.nil?
         end
         if newvm.flavor.nil?
           raise "Could not find template to create VM."
         end
-        newvm.flavor = newvm.flavor.first
         newvm.name = config[:vm_hostname]
         newvm.flavor.user_variables = config[:user_variables]
         newvm.flavor.context['SSH_PUBLIC_KEY'] = File.read(config[:public_key_path]).chomp

--- a/lib/kitchen/driver/opennebula_version.rb
+++ b/lib/kitchen/driver/opennebula_version.rb
@@ -21,6 +21,6 @@ module Kitchen
   module Driver
 
     # Version string for Opennebula Kitchen driver
-    OPENNEBULA_VERSION = "0.1.0.dev"
+    OPENNEBULA_VERSION = "0.1.1"
   end
 end


### PR DESCRIPTION
The 1st non pre-release build of `kitchen-opennebula` plugin.

The release consists of mostly hotfixes and some minor improvements.
### Overview
- Relax the test-kitchen dependency in anticipation for 1.3.0 test-kitchen release
- Adding opennebula gem as dependency [caused by: fog/fog#3295]
- Make fog version dependency
- Fixes test-kitchen#4 by adding timeouts to wait for the VM to boot, and for SSH to become available
- Fixes test-kitchen#4 by adding check that prevents create phase completion until user (configured by :username) has passwordless sudo setup properly
- Ensures that kitchen always gets a flavor (template) by using the first flavor returned by get_by_filter
- Ensures only one flavor (template) is returned
- Fixed overrides for both context variables and user variables (YAML translated to symbols, which prevented context overrides from working)
